### PR TITLE
ci: remove `evaluate`'s dependency on `lint`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Check for common mistakes with nix-linter
         run: nix-shell -p nix-linter --run "nix-linter -r ."
   evaluate:
-    needs: [lint]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0


### PR DESCRIPTION
Running the jobs in parallel is much faster.