### PR TITLE
fix(hosts.server): caddy returning 400 for all http requests

### DIFF
--- a/hosts/server.nix
+++ b/hosts/server.nix
@@ -56,7 +56,6 @@
           server {
             listen 80;
             listen [::]:80;
-            proxy_protocol on;
             proxy_pass localhost:8001;
           }
 


### PR DESCRIPTION
Caddy is not listening for proxy protocol on port 80. When it receives a proxy request, it responds with 400.