### PR TITLE
fix(hosts.thinkpad-e580): amdgpu reinitialising

### DIFF
--- a/hosts/thinkpad-e580/default.nix
+++ b/hosts/thinkpad-e580/default.nix
@@ -39,8 +39,6 @@
   sound.enable = true;
 
   services = {
-    auto-cpufreq.enable = true;
-
     # this host isn't a lighthouse, but all hosts should have a unique port for NAT traversal to avoid overlaps
     nebula.networks."joel".listen.port = 4240;
 
@@ -53,6 +51,8 @@
       enable = true;
       guiAddress = "0.0.0.0:8384";
     };
+
+    tlp.enable = true;
 
     xserver = {
       enable = true;


### PR DESCRIPTION
For the past few months I've had my AMD GPU making my system's screen freeze
every ~10-20 seconds. The following was logged in the journal:

```
Feb 06 16:36:47 thinkpad-e580 kernel: [drm] PCIE GART of 256M enabled (table at 0x000000F400000000).
Feb 06 16:36:47 thinkpad-e580 kernel: [drm] UVD and UVD ENC initialized successfully.
Feb 06 16:36:47 thinkpad-e580 kernel: [drm] VCE initialized successfully.
```

I had searched online:

> It turned out to be the status line script I was using in tmux, which called
> the sensors program. For some reason, running sensors on this machine
> reinitializes the PCIE GART. So, I'm just reading the temperature from /sys
> now.
>
> https://bbs.archlinux.org/viewtopic.php?id=263814

I couldn't find any scripts running that called these sensors. Until today.
auto-cpufreq was calling the sensors in my GPU! It was why my system kept
freezing for a second, way too often. Disabling it stopped this issue.

Now, I use TLP. It still calls my GPU's sensors, but so far I've only noticed
when starting the TLP service. Not scheduled every ~10-20 seconds.

Looks like this has also solved my battery power problem. Previously I would
get 2 hours of power out of my laptop. My system is now predicting a battery
that lasts twice as long...