### PR TITLE
fix: caddy returning 400 when load balanced http (not https)

### DIFF
--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -56,7 +56,6 @@
           server {
             listen 8000;
             listen [::]:8000;
-            proxy_protocol on;
             proxy_pass http_servers;
           }
 


### PR DESCRIPTION
Caddy is only expecting proxy protocol for HTTPS.

I fixed this ealier for https requests that are directly to the node, but (for some reason) not from a load balancer. This correctly fixes this.