### PR TITLE
feat(hosts.thinkpad-e580): disable nix-serve

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,9 +164,7 @@
     },
     "home-manager": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1645796113,
@@ -283,6 +281,20 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1645765209,
+        "narHash": "sha256-tLpNZlpCjWpbbxhDgQ/e5z2fL1RZGLYJWkkCOJNqlcI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "056c34167d3210a674ef21691afbbce1ed63f8ca",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1645783086,
         "narHash": "sha256-L8YfZmwx3FretBLq55gWt6qgFUsns66l0hb+Ci8V1yI=",
         "owner": "nixos",
@@ -320,7 +332,7 @@
         "flake-utils": "flake-utils_2",
         "home-manager": "home-manager",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "nur": "nur"
       }
     },

--- a/hosts/thinkpad-e580/default.nix
+++ b/hosts/thinkpad-e580/default.nix
@@ -42,11 +42,6 @@
     # this host isn't a lighthouse, but all hosts should have a unique port for NAT traversal to avoid overlaps
     nebula.networks."joel".listen.port = 4240;
 
-    nix-serve = {
-      enable = true;
-      secretKeyFile = "/var/binary-cache.pem";
-    };
-
     syncthing = {
       enable = true;
       guiAddress = "0.0.0.0:8384";
@@ -72,7 +67,6 @@
       videoDrivers = [ "amdgpu" "radeon" "nouveau" "modesetting" "fbdev" ];
     };
   };
-  systemd.services.nix-serve.environment.HOME = "/dev/null"; # bug fix
 
   programs = {
     gnupg.agent = {
@@ -120,11 +114,6 @@
         ${config.networking.hostName}.dev.joel.tokyo {
           import joel.tokyo
           respond "Hello world"
-        }
-
-        nix.${config.networking.hostName}.dev.joel.tokyo {
-          import joel.tokyo
-          reverse_proxy 172.17.0.1:5000
         }
 
         syncthing.srv.${config.networking.hostName}.dev.joel.tokyo {

--- a/hosts/thinkpad-e580/keys/binary-cache.pub
+++ b/hosts/thinkpad-e580/keys/binary-cache.pub
@@ -1,1 +1,0 @@
-nix.thinkpad-e580.dev.joel.tokyo:VKxPlWcfxi5dxgm3FdYJ/j116XD+5QULUU4jEtQVRmw=

--- a/profiles/common/default.nix
+++ b/profiles/common/default.nix
@@ -1,7 +1,10 @@
 { config, pkgs, self, ... }:
 
+with builtins;
+
 let
-  hosts = builtins.attrNames self.nixosConfigurations;
+  hosts = attrNames self.nixosConfigurations;
+  cacheHosts = filter (host: pathExists "${../../hosts}/${host}/keys/binary-cache.pub") hosts;
 in
 
 {
@@ -23,8 +26,9 @@ in
     '';
     settings = {
       trusted-users = [ "root" "joel" ];
-      substituters = map (x: "https://nix.${x}.${config.networking.domain}") hosts;
-      trusted-public-keys = map (x: builtins.readFile (../../. + "/hosts/${x}/keys/binary-cache.pub")) hosts;
+      substituters = map (x: "https://nix.${x}.${config.networking.domain}") cacheHosts;
+      trusted-public-keys =
+        map (x: readFile (../../. + "/hosts/${x}/keys/binary-cache.pub")) cacheHosts;
     };
   };
   nixpkgs.config = import ./nixpkgs.nix;

--- a/profiles/ssh.nix
+++ b/profiles/ssh.nix
@@ -7,7 +7,7 @@ let
 in
 {
   services.openssh = {
-    enable = pathExists (../hosts + "/${hostName}/keys/ssh.pub");
+    enable = pathExists "${../hosts}/${hostName}/keys/ssh.pub";
     passwordAuthentication = false;
   };
 


### PR DESCRIPTION
Nix is not reliable if a binary cache is down. My cluster should still be able to function regardless of whether my laptop is on or not, so I'm going to disable my laptop's binary cache.

I'm doing this now because I'm finally getting some stuff running that does not need any action from me (and does not need my laptop on). See jyooru/nix-minecraft-servers#49.