### PR TITLE
fix: cache keys need old domain for backwards compatibility

### DIFF
--- a/profiles/common/default.nix
+++ b/profiles/common/default.nix
@@ -28,7 +28,11 @@ in
       trusted-users = [ "root" "joel" ];
       substituters = map (x: "https://nix.${x}.${config.networking.domain}") cacheHosts;
       trusted-public-keys =
-        map (x: readFile (../../. + "/hosts/${x}/keys/binary-cache.pub")) cacheHosts;
+        let
+          currentKeys = map (x: readFile (../../. + "/hosts/${x}/keys/binary-cache.pub")) cacheHosts;
+          oldKeys = map (replaceStrings [ ".joel.tokyo" ] [ ".dev.joel.tokyo" ]) currentKeys;
+        in
+        currentKeys ++ oldKeys;
     };
   };
   nixpkgs.config = import ./nixpkgs.nix;


### PR DESCRIPTION
as some stuff i have in my nix store is signed with the old domain, which is not trusted without these changes

#117