### PR TITLE
ci(dependabot): disable github actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,6 @@ updates:
       time: "22:30"
     target-branch: "chore/update"
 
-  - package-ecosystem: "github-actions"
-    directory: "/templates/python/.github/workflows"
-    schedule:
-      day: "friday"
-      interval: "weekly"
-      time: "22:30"
-    target-branch: "chore/update"
-
   - package-ecosystem: "pip"
     directory: "/templates/python"
     schedule:


### PR DESCRIPTION
it doesn't work in other directories - in other repositories the dependency graph picks up yml files in the /.github/workflows, but it doesn't seem to like them in other directories