### PR TITLE
revert: fix: disable portege-r700-b

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -12,7 +12,7 @@ mapAttrs
   (exportModules [
     ./ga-z77-d3h
     ./portege-r700-a
-    # ./portege-r700-b
+    ./portege-r700-b
     ./portege-z930
     ./thinkpad-e580
   ])

--- a/profiles/file-sync/default.nix
+++ b/profiles/file-sync/default.nix
@@ -7,14 +7,14 @@ let
   all = cluster ++ [ "galaxy-a22" ];
   allBackup = backup ++ [ "galaxy-a22" ];
   backup = [ "thinkpad-e580" "portege-r700-a" "ga-z77-d3h" ]; # nodes in cluster with big hard drive plus laptop
-  cluster = [ "thinkpad-e580" "portege-r700-a" "portege-z930" "ga-z77-d3h" ]; # all nodes in cluster plus laptop
+  cluster = [ "thinkpad-e580" "portege-r700-a" "portege-r700-b" "portege-z930" "ga-z77-d3h" ]; # all nodes in cluster plus laptop
   devices = mapAttrs
     (name: id: { addresses = [ "tcp://${name}.${domain}:22000" ]; inherit id; })
     {
       "thinkpad-e580" = "XBWJHAC-FE2X3L2-MSS5ID4-JVE3VOV-HKWEAD3-4V6QRGC-JUKFOKR-5JDOVAE";
       "galaxy-a22" = "AWUGYY2-D3Y2JT7-VXU6T3I-SOYSY7T-PA3O4ST-QWE5MHL-6BWY6NJ-6RKXZAM";
       "portege-r700-a" = "O4R7UYN-CQPXSCH-NOCFRNH-6KW63ZX-GXXZQR2-M5L44FP-7WN5CV5-JSRBHQ4";
-      # "portege-r700-b" = "ZYK4DWO-APF4R5A-XBDBGXV-FO46RGA-XPGZPJK-VGCC57W-DIJ6DWP-4YMACQL";
+      "portege-r700-b" = "ZYK4DWO-APF4R5A-XBDBGXV-FO46RGA-XPGZPJK-VGCC57W-DIJ6DWP-4YMACQL";
       "portege-z930" = "JOYBHZH-W4IQAET-WVLQT2J-FUYKMAR-XFJCXKA-D3KQFWC-XE3DNDU-3VJ33QZ";
       "ga-z77-d3h" = "QMOXUMI-JSL766T-CUTKFMC-TUUG3MC-FYWAGI7-4DRVYYC-KU6TDPS-QPBGEAV";
     };

--- a/profiles/server/default.nix
+++ b/profiles/server/default.nix
@@ -56,7 +56,7 @@
 
           upstream http_servers {
             server 10.42.0.11:8001;
-            # server 10.42.0.12:8001;
+            server 10.42.0.12:8001;
             server 10.42.0.13:8001;
             server 10.42.0.14:8001;
           }
@@ -76,7 +76,7 @@
 
           upstream https_servers {
             server 10.42.0.11:44301;
-            # server 10.42.0.12:44301;
+            server 10.42.0.12:44301;
             server 10.42.0.13:44301;
             server 10.42.0.14:44301;
           }

--- a/profiles/vpn/default.nix
+++ b/profiles/vpn/default.nix
@@ -6,7 +6,7 @@ let
 
   lighthouses = {
     "portege-r700-a" = "10.42.0.11";
-    # "portege-r700-b" = "10.42.0.12";
+    "portege-r700-b" = "10.42.0.12";
     "portege-z930" = "10.42.0.13";
     "ga-z77-d3h" = "10.42.0.14";
   };
@@ -14,7 +14,7 @@ let
   lighthouseIps = attrValues lighthouses;
   staticHosts = {
     "10.42.0.11" = [ "home.joel.tokyo:4241" "192.168.0.11:4241" ];
-    # "10.42.0.12" = [ "home.joel.tokyo:4242" "192.168.0.12:4242" ];
+    "10.42.0.12" = [ "home.joel.tokyo:4242" "192.168.0.12:4242" ];
     "10.42.0.13" = [ "home.joel.tokyo:4243" "192.168.0.13:4243" ];
     "10.42.0.14" = [ "home.joel.tokyo:4244" "192.168.0.14:4244" ];
   };

--- a/profiles/yggdrasil/ports.nix
+++ b/profiles/yggdrasil/ports.nix
@@ -1,6 +1,6 @@
 {
   ga-z77-d3h = 20074;
   portege-r700-a = 20071;
-  # portege-r700-b = 20072;
+  portege-r700-b = 20072;
   portege-z930 = 20073;
 }

--- a/users/profiles/ssh/default.nix
+++ b/users/profiles/ssh/default.nix
@@ -10,7 +10,7 @@ with lib;
         hosts = {
           "l" = "thinkpad-e580";
           "1" = "portege-r700-a";
-          # "2" = "portege-r700-b";
+          "2" = "portege-r700-b";
           "3" = "portege-z930";
           "4" = "ga-z77-d3h";
         };


### PR DESCRIPTION
This reverts commit e37338d88e03f8da3e319f96ee215b18b3177372.

i was rebooting each server to update them, accidentally rebooted portege-r700-b instead of a without realising and it just booted? it managed to uncorrupt itself after having a few month sleep

i am not suprised that this old hardware managed to break for no reason, then fix it self for no reason

Closes #148 