### PR TITLE
fix: don't change ipfs connection manager on thinkpad-e580

### DIFF
--- a/hosts/thinkpad-e580/default.nix
+++ b/hosts/thinkpad-e580/default.nix
@@ -35,10 +35,7 @@
     ipfs = {
       # let's me still use offline ipfs without killing my battery
       # have an alias setup to turn it back on easily
-      extraConfig = {
-        Reprovider.Strategy = "pinned";
-        Swarm.ConnMgr.Type = "none";
-      };
+      extraConfig.Reprovider.Strategy = "pinned";
 
       swarmAddress = [
         "/ip4/0.0.0.0/tcp/4000"


### PR DESCRIPTION
don't think it does what it's supposed to do, now i have 9000 peers...?